### PR TITLE
chore(tests): run tests on pre-push

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   },
   "husky": {
     "hooks": {
-      "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true"
+      "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true",
+      "pre-push": "yarn test"
     }
   },
   "config": {


### PR DESCRIPTION
I choose to do it in `pre-push` and not on `pre-commit` in order to avoid the chance to not run the tests using `commit -n`