### PR TITLE
feat(new hook): a hook for defining the options for a component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   SearchBarUpdatedEvent,
   PreviewCompletedEvent,
   SearchBarCancelPressedEvent,
+  Options,
 } from 'react-native-navigation'
 
 /**
@@ -412,6 +413,27 @@ function useNavigationPreviewComplete(
   }, [handler, componentId])
 }
 
+/**
+ * Sets navigation options - equivalent of static options in class components.
+ * [more info](https://wix.github.io/react-native-navigation/api/options-api#mergeoptions)
+ */
+function useNavigationOptions(
+  /**
+   * Component reference id. The id of the component for which the options are related.
+   */
+  componentId: string, 
+
+  /**
+   * The options object to be passed for navigation.
+   * [more info](https://wix.github.io/react-native-navigation/api/options-root)
+   */
+  options: Options
+) {
+  useLayoutEffect(() => {
+    Navigation.mergeOptions(componentId, options);
+  }, []);
+}
+
 export {
   useNavigationComponentDidAppear,
   useNavigationComponentDidDisappear,
@@ -427,4 +449,5 @@ export {
   useNavigationSearchBarUpdate,
   useNavigationSearchBarCancelPress,
   useNavigationPreviewComplete,
+  useNavigationOptions,
 }


### PR DESCRIPTION
In class components, one would declare a static function `options` in which the navigation options
for the class component would be declared.

In functional components one could define those options via `Component.options =...` while this approach works, I felt that it isn't type safe and rather clumsy. 

Using the `mergeOptions` method with `useLayoutEffect` allows for a simple and type safe way to define custom `options` per component.