### PR TITLE
Fix args precedence in useNavigation

### DIFF
--- a/src/hooks/useNavigation.test.tsx
+++ b/src/hooks/useNavigation.test.tsx
@@ -41,6 +41,23 @@ describe('useNavigation', () => {
     expect(result.error).toBeUndefined()
   })
 
+  it('should return helpers taking precedence componentId over CompoenentIdProvider', () => {
+    jest.spyOn(createNavigationCommands, 'default')
+
+    const wrapper = ({ children }) => (
+      <NavigationProvider value={{ componentId: 'componentId' }}>{children}</NavigationProvider>
+    )
+
+    const { result, unmount } = renderHook(() => useNavigation('componentIdArgument'), { wrapper })
+
+    unmount()
+
+    expect(createNavigationCommands.default).toHaveBeenCalledWith('componentIdArgument')
+
+    expect(Object.keys(result.current)).toEqual(navigationCommandKeys)
+    expect(result.error).toBeUndefined()
+  })
+
   it('should throw when not using NavigationProvider nor componentId as argument', () => {
     const { result, unmount } = renderHook(() => useNavigation())
 

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -17,7 +17,9 @@ const useNavigation = (
    */
   componentId?: string
 ) => {
-  const { componentId: id = componentId } = useContext(NavigationContext)
+  const { componentId: contextComponentId } = useContext(NavigationContext)
+
+  const id = componentId || contextComponentId
 
   if (!id) {
     throw new Error('Missing "componentId". Use NavigationContext or pass "componentId" as argument.')


### PR DESCRIPTION
`useNavigation` hook  now takes precedence componentId argument over componentId from the context. 

This is related to #39 and should fix the unexpected behaviour.