### PR TITLE
Change useLayoutEffect of useNavigationComponentHooks to useEffect

### DIFF
--- a/src/hooks/useNavigationComponentDidAppear.ts
+++ b/src/hooks/useNavigationComponentDidAppear.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useContext } from 'react'
+import { useEffect, useContext } from 'react'
 import { Navigation, ComponentDidAppearEvent } from 'react-native-navigation'
 import { NavigationContext } from '../contexts'
 import triggerIfComponentIdMatches from '../helpers/triggerIfComponentIdMatches'
@@ -51,7 +51,7 @@ function useNavigationComponentDidAppear(handler: EventHandler, componentIdOrOpt
 
   warnIfMissingComponentId('useNavigationComponentDidAppear', componentId, global)
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const subscription = Navigation.events().registerComponentDidAppearListener((event: ComponentDidAppearEvent) =>
       triggerIfComponentIdMatches(handler, event, componentId)
     )

--- a/src/hooks/useNavigationComponentDidDisappear.ts
+++ b/src/hooks/useNavigationComponentDidDisappear.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useContext } from 'react'
+import { useEffect, useContext } from 'react'
 import { Navigation, ComponentDidDisappearEvent } from 'react-native-navigation'
 import { NavigationContext } from '../contexts'
 import triggerIfComponentIdMatches from '../helpers/triggerIfComponentIdMatches'
@@ -51,7 +51,7 @@ function useNavigationComponentDidDisappear(handler: EventHandler, componentIdOr
 
   warnIfMissingComponentId('useNavigationComponentDidDisappear', componentId, global)
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const subscription = Navigation.events().registerComponentDidDisappearListener(
       (event: ComponentDidDisappearEvent) => triggerIfComponentIdMatches(handler, event, componentId)
     )


### PR DESCRIPTION
I changed `useLayoutEffect` to `useEffect` at useNavigationComponentDidAppear & useNavigationComponentDidDisppear.

```
const useNavigationComponentDidAppear = (
  handler: EventHandler,
  componentId: string
) => {
  useLayoutEffect(() => {
    const subscription = Navigation.events().registerComponentDidAppearListener(
      (event: ComponentDidAppearEvent) =>
        triggerIfComponentIdMatches(handler, event, componentId)
    );
    return () => subscription.remove();
  }, [handler, componentId]);
};

```
As you can see, in previous code, `useNavigationComponentDidAppear` worked by using `useLayoutEffect` to `registerComponentDidAppearListener` to navigation events. (The signature of `useNavigationComponentDidDisppear` is the same) 

So if user use setState inside `useNavigationComponentDidAppear`, the next call will not be called because the component will be updated before the next effect is executed.  

That's why some user experiences this issue : https://github.com/underscopeio/react-native-navigation-hooks/issues/62



  
### Reference 

- https://github.com/facebook/react/blob/main/packages/react/src/ReactHooks.js#L117
- https://stackoverflow.com/questions/53781632/whats-useeffect-execution-order-and-its-internal-clean-up-logic-in-react-hooks
- https://blog.logrocket.com/useeffect-vs-uselayouteffect-examples/


